### PR TITLE
Don't run integration tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,11 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         php: [8.3, 8.2, 8.1, 8.0]
         dependency-version: [prefer-lowest, prefer-stable]
 
@@ -29,4 +30,4 @@ jobs:
         run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: APP_ENV=ci ./vendor/bin/phpunit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,10 +55,9 @@ services:
     container_name: php-opentsdb-client-lib-opentsdb
     image: petergrace/opentsdb-docker:latest
     environment:
-      - WAITSECS=30 # Give time for hbase to shutdown, otherwise data corruption may result
+      - WAITSECS=30 # Give time for hbase to shut down, otherwise data corruption may result
     ports:
       - 4242:4242
-      - 60030:60030
     networks:
       - php-opentsdb-client-lib
     volumes:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,6 @@
     </testsuite>
   </testsuites>
   <php>
-    <server name="APP_ENV" value="testing"/>
+    <env name="APP_ENV" value="testing"/>
   </php>
 </phpunit>

--- a/test/Integration/OpenTsdbClientTest.php
+++ b/test/Integration/OpenTsdbClientTest.php
@@ -22,7 +22,9 @@ final class OpenTsdbClientTest extends TestCase
 {
     public function testSuccess(): void
     {
-        $this->markTestSkipped('Only for development environment. Need to pull opentsdb container to GitHub.');
+        if ($_ENV['APP_ENV'] === 'ci') {
+            $this->markTestSkipped('Only for development environment. Need to pull opentsdb container to GitHub.');
+        }
 
         $dataPointList[] = new DataPoint(
             metric: 'temperature',


### PR DESCRIPTION
Tried service opentsdb but doesn't help. It is not starting for some reason. Just ignoring it in CI, will run tests locally using docker-compose.